### PR TITLE
android平台的TextField BUG修复和改进

### DIFF
--- a/CrossApp/control/CATextField.cpp
+++ b/CrossApp/control/CATextField.cpp
@@ -80,7 +80,6 @@ bool CATextField::becomeFirstResponder()
 		attachWithIME();
     }
     return result;
-    
 }
 
 CATextField* CATextField::createWithFrame(const CCRect& frame)
@@ -315,6 +314,12 @@ bool CATextField::ccTouchBegan(CATouch *pTouch, CAEvent *pEvent)
             
 			m_pCursorMark->setCenterOrigin(CCPoint(getCursorX() + m_iHoriMargins, m_obContentSize.height / 2));
         }
+
+#if CC_TARGET_PLATFORM==CC_PLATFORM_ANDROID
+        CCEGLView * pGlView = CAApplication::getApplication()->getOpenGLView();
+        pGlView->setIMECursorPos(getCursorPos());
+#endif
+
     }
     else
     {
@@ -509,7 +514,7 @@ void CATextField::adjustCursorMoveForward()
     }
 }
 
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 void CATextField::deleteForward()
 {
     if (m_nInputType == KEY_BOARD_INPUT_PASSWORD)
@@ -608,7 +613,8 @@ void CATextField::cursorMoveForward(bool selected)
 
     adjustCursorMoveForward();
 }
-
+#endif
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 void CATextField::copyToClipboard(std::string *content)
 {
     if (m_nInputType == KEY_BOARD_INPUT_PASSWORD || m_charRange.first == m_charRange.second)
@@ -673,6 +679,17 @@ void CATextField::selectAll()
 const char* CATextField::getContentText()
 {
     return m_sText.c_str();
+}
+
+int CATextField::getCursorPos()
+{
+    return getStringCharCount(m_sText.substr(0, m_iCurPos));
+}
+
+std::pair<int, int> CATextField::getCharRange()
+{
+    return std::make_pair(getStringCharCount(m_sText.substr(0, m_charRange.first)),
+        getStringCharCount(m_sText.substr(0, m_charRange.second)));
 }
 
 void CATextField::setBackgroundView(CrossApp::CAView *var)

--- a/CrossApp/control/CATextField.h
+++ b/CrossApp/control/CATextField.h
@@ -161,7 +161,7 @@ protected:
     virtual bool canAttachWithIME();
     virtual bool canDetachWithIME();
     int getStringLength(const std::string &var);
-    int getStringCharCount(const std::string &var);
+    static int getStringCharCount(const std::string &var);
     virtual void setContentSize(const CCSize& var);
     void         initMarkSprite();
     virtual bool ccTouchBegan(CATouch *pTouch, CAEvent *pEvent);
@@ -176,11 +176,12 @@ protected:
     void adjustCursorMoveBackward();
     void adjustCursorMoveForward();
 
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     virtual void deleteForward();
     virtual void cursorMoveBackward(bool selected);
     virtual void cursorMoveForward(bool selected);
-
+#endif
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
     virtual void copyToClipboard(std::string *content);
     virtual void cutToClipboard(std::string *content);
     virtual void pasteFromClipboard(const char *content);
@@ -188,6 +189,9 @@ protected:
 #endif
 
     virtual const char* getContentText();
+    virtual int getCursorPos();
+    virtual std::pair<int, int> getCharRange();
+
 private:
 	std::vector<TextAttribute> m_vTextFiledChars;
 	int m_iCurPos;

--- a/CrossApp/controller/CAViewController.cpp
+++ b/CrossApp/controller/CAViewController.cpp
@@ -217,8 +217,7 @@ void CAViewController::dismissModalViewController(bool animated)
 #pragma CANavigationController
 
 CANavigationController::CANavigationController()
-:m_pViewControllers(NULL)
-,m_bNavigationBarHidden(false)
+:m_bNavigationBarHidden(false)
 ,m_bPopViewController(false)
 ,m_pNavigationBarBackGroundImage(NULL)
 ,m_sNavigationBarBackGroundColor(CAColor_white)

--- a/CrossApp/dispatcher/CAIMEDelegate.h
+++ b/CrossApp/dispatcher/CAIMEDelegate.h
@@ -4,6 +4,7 @@
 #define __CC_IME_DELEGATE_H__
 
 #include <string>
+#include <utility>
 #include "basics/CAGeometry.h"
 
 NS_CC_BEGIN
@@ -71,11 +72,12 @@ protected:
     */
     virtual void deleteBackward() {}
 
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     virtual void deleteForward() {}
     virtual void cursorMoveBackward(bool selected) {CC_UNUSED_PARAM(selected);}
     virtual void cursorMoveForward(bool selected) {CC_UNUSED_PARAM(selected);}
-
+#endif
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
     virtual void copyToClipboard(std::string *content) {CC_UNUSED_PARAM(content);}
     virtual void cutToClipboard(std::string *content) {CC_UNUSED_PARAM(content);}
     virtual void pasteFromClipboard(const char *content) {CC_UNUSED_PARAM(content);}
@@ -89,6 +91,8 @@ protected:
     @brief    Called by CAIMEDispatcher for text stored in delegate.
     */
     virtual const char * getContentText() { return 0; }
+    virtual int getCursorPos() { return 0; }
+    virtual std::pair<int, int> getCharRange() { return std::pair<int, int>(0, 0); }
 
     //////////////////////////////////////////////////////////////////////////
     // keyboard show/hide notification

--- a/CrossApp/dispatcher/CAIMEDispatcher.cpp
+++ b/CrossApp/dispatcher/CAIMEDispatcher.cpp
@@ -261,8 +261,7 @@ void CAIMEDispatcher::dispatchDeleteBackward()
     } while (0);
 }
 
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
-
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 void CAIMEDispatcher::dispatchDeleteForward()
 {
     do
@@ -301,7 +300,8 @@ void CAIMEDispatcher::dispatchCursorMoveForward(bool selected)
         m_pImpl->m_DelegateWithIme->cursorMoveForward(selected);
     } while (0);
 }
-
+#endif
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
 void CAIMEDispatcher::dispatchCopyToClipboard(std::string *content)
 {
     do
@@ -364,6 +364,24 @@ const char * CAIMEDispatcher::getContentText()
         pszContentText = m_pImpl->m_DelegateWithIme->getContentText();
     }
     return (pszContentText) ? pszContentText : "";
+}
+
+int CAIMEDispatcher::getCursorPos()
+{
+    if (m_pImpl && m_pImpl->m_DelegateWithIme)
+    {
+        return m_pImpl->m_DelegateWithIme->getCursorPos();
+    }
+    return 0;
+}
+
+std::pair<int, int> CAIMEDispatcher::getCharRange()
+{
+    if (m_pImpl && m_pImpl->m_DelegateWithIme)
+    {
+        return m_pImpl->m_DelegateWithIme->getCharRange();
+    }
+    return std::pair<int, int>(0, 0);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/CrossApp/dispatcher/CAIMEDispatcher.h
+++ b/CrossApp/dispatcher/CAIMEDispatcher.h
@@ -4,6 +4,7 @@
 #define __CC_IME_DISPATCHER_H__
 
 #include <string>
+#include <utility>
 #include "CAIMEDelegate.h"
 NS_CC_BEGIN
 
@@ -49,11 +50,12 @@ public:
     
     void dispatchGetKeyBoradReturnCallBack();
 
-#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
     void dispatchDeleteForward();
     void dispatchCursorMoveBackward(bool selected);
     void dispatchCursorMoveForward(bool selected);
-
+#endif
+#if CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
     void dispatchCopyToClipboard(std::string *content);
     void dispatchCutToClipboard(std::string *content);
     void dispatchPasteFromClipboard(const char *content);
@@ -64,6 +66,8 @@ public:
     @brief Get the content text from CAIMEDelegate, retrieved previously from IME.
     */
     const char * getContentText();
+    int getCursorPos();
+    std::pair<int, int> getCharRange();
 
     //////////////////////////////////////////////////////////////////////////
     // dispatch keyboard notification

--- a/CrossApp/platform/android/CCEGLView.cpp
+++ b/CrossApp/platform/android/CCEGLView.cpp
@@ -96,5 +96,10 @@ void CCEGLView::setIMEKeyboardReturnDone()
 {
     setKeyboardReturnType(21);
 }
+
+void CCEGLView::setIMECursorPos(int pos)
+{
+    setCursorPos(pos);
+}
 NS_CC_END
 

--- a/CrossApp/platform/android/CCEGLView.h
+++ b/CrossApp/platform/android/CCEGLView.h
@@ -32,6 +32,8 @@ public:
     virtual void setIMEKeyboardReturnSearch();
     
     virtual void setIMEKeyboardReturnDone();
+
+    void setIMECursorPos(int pos);
     // static function
     /**
     @brief    get the shared main open gl window

--- a/CrossApp/platform/android/java/src/org/CrossApp/lib/Cocos2dxEditText.java
+++ b/CrossApp/platform/android/java/src/org/CrossApp/lib/Cocos2dxEditText.java
@@ -50,7 +50,8 @@ public class Cocos2dxEditText extends EditText {
 		super.onKeyDown(pKeyCode, pKeyEvent);
 
 		/* Let GlSurfaceView get focus if back key is input. */
-		if (pKeyCode == KeyEvent.KEYCODE_BACK || pKeyCode == KeyEvent.KEYCODE_MENU) {
+		if (pKeyCode == KeyEvent.KEYCODE_BACK || pKeyCode == KeyEvent.KEYCODE_MENU
+				|| pKeyCode == KeyEvent.KEYCODE_DPAD_LEFT || pKeyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
 			this.mCocos2dxGLSurfaceView.requestFocus();
 			this.mCocos2dxGLSurfaceView.onKeyDown(pKeyCode, pKeyEvent);
 		}

--- a/CrossApp/platform/android/java/src/org/CrossApp/lib/Cocos2dxGLSurfaceView.java
+++ b/CrossApp/platform/android/java/src/org/CrossApp/lib/Cocos2dxGLSurfaceView.java
@@ -34,6 +34,9 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 	private final static int KEY_BOARD_RETURNTYPE_SEARCH=22;
 	private final static int KEY_BOARD_RETURNTYPE_SEND=23;
 	private final static int RESET_TEXT=13;
+
+	private final static int SET_CURSOR_POS = 33;
+
 	// ===========================================================
 	// Fields
 	// ===========================================================
@@ -80,7 +83,8 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 							Cocos2dxGLSurfaceView.this.mCocos2dxEditText.setText("");
 							text = Cocos2dxGLSurfaceView.this.mCocos2dxEditText;
 							final String text = (String) msg.obj;
-							Cocos2dxGLSurfaceView.this.mCocos2dxEditText.append(text);
+							Cocos2dxGLSurfaceView.this.mCocos2dxEditText.setText(text);
+							Cocos2dxGLSurfaceView.this.mCocos2dxEditText.setSelection(msg.arg1);
 							Cocos2dxGLSurfaceView.sCocos2dxTextInputWraper.setOriginText(text);
 							
 							//
@@ -91,7 +95,12 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 							Log.d("GLSurfaceView", "showSoftInput");
 						}
 						break;
-
+					case SET_CURSOR_POS:
+						if (null != Cocos2dxGLSurfaceView.this.mCocos2dxEditText) {
+							text = Cocos2dxGLSurfaceView.this.mCocos2dxEditText;
+							Cocos2dxGLSurfaceView.this.mCocos2dxEditText.setSelection(msg.arg1);
+						}
+						break;
 					case HANDLER_CLOSE_IME_KEYBOARD:
 						if (null != Cocos2dxGLSurfaceView.this.mCocos2dxEditText) {
 							Cocos2dxGLSurfaceView.this.mCocos2dxEditText.removeTextChangedListener(Cocos2dxGLSurfaceView.sCocos2dxTextInputWraper);
@@ -158,30 +167,36 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 	// ===========================================================
 
 
-       public static Cocos2dxGLSurfaceView getInstance() {
-	   return mCocos2dxGLSurfaceView;
-       }
-       
-       public void setKeyBoardType(int type)
-       {
-    	   
-    	   final Message msg = new Message();
-   			msg.what = type;
-   			Cocos2dxGLSurfaceView.sHandler.sendMessage(msg);
-       }
-       public void setKeyBoardRetrunType(int type)
-       {
-    	   final Message msg = new Message();
-  			msg.what = type;
-  			Cocos2dxGLSurfaceView.sHandler.sendMessage(msg);
-       }
-       public static void queueAccelerometer(final float x, final float y, final float z, final long timestamp) {	
-	   mCocos2dxGLSurfaceView.queueEvent(new Runnable() {
-		@Override
-		    public void run() {
-			    Cocos2dxAccelerometer.onSensorChanged(x, y, z, timestamp);
-		}
-	    });
+	public static Cocos2dxGLSurfaceView getInstance() {
+		return mCocos2dxGLSurfaceView;
+	}
+
+	public void setKeyBoardType(int type) {
+		final Message msg = new Message();
+		msg.what = type;
+		Cocos2dxGLSurfaceView.sHandler.sendMessage(msg);
+	}
+
+	public void setKeyBoardRetrunType(int type) {
+		final Message msg = new Message();
+		msg.what = type;
+		Cocos2dxGLSurfaceView.sHandler.sendMessage(msg);
+	}
+
+	public void setCursorPos(int pos) {
+		final Message msg = new Message();
+		msg.what = SET_CURSOR_POS;
+		msg.arg1 = pos;
+		Cocos2dxGLSurfaceView.sHandler.sendMessage(msg);
+	}
+
+	public static void queueAccelerometer(final float x, final float y, final float z, final long timestamp) {
+		mCocos2dxGLSurfaceView.queueEvent(new Runnable() {
+			@Override
+			public void run() {
+				Cocos2dxAccelerometer.onSensorChanged(x, y, z, timestamp);
+			}
+		});
 	}
 
 	public void setCocos2dxRenderer(final Cocos2dxRenderer renderer) {
@@ -360,6 +375,28 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 					}
 				});
 				return true;
+			case KeyEvent.KEYCODE_DPAD_LEFT:
+				if (null != Cocos2dxGLSurfaceView.this.mCocos2dxEditText && Cocos2dxGLSurfaceView.this.mCocos2dxEditText.requestFocus()) {
+					Cocos2dxGLSurfaceView.text = Cocos2dxGLSurfaceView.this.mCocos2dxEditText;
+					this.queueEvent(new Runnable() {
+						@Override
+						public void run() {
+							Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleKeyDown(pKeyCode);
+						}
+					});
+				}
+				return true;
+			case KeyEvent.KEYCODE_DPAD_RIGHT:
+				if (null != Cocos2dxGLSurfaceView.this.mCocos2dxEditText && Cocos2dxGLSurfaceView.this.mCocos2dxEditText.requestFocus()) {
+					Cocos2dxGLSurfaceView.text = Cocos2dxGLSurfaceView.this.mCocos2dxEditText;
+					this.queueEvent(new Runnable() {
+						@Override
+						public void run() {
+							Cocos2dxGLSurfaceView.this.mCocos2dxRenderer.handleKeyDown(pKeyCode);
+						}
+					});
+				}
+				return true;
 			default:
 				return super.onKeyDown(pKeyCode, pKeyEvent);
 		}
@@ -377,9 +414,8 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
 		final Message msg = new Message();
 		msg.what = Cocos2dxGLSurfaceView.HANDLER_OPEN_IME_KEYBOARD;
 		msg.obj = Cocos2dxGLSurfaceView.mCocos2dxGLSurfaceView.getContentText();
+		msg.arg1 = Cocos2dxGLSurfaceView.mCocos2dxGLSurfaceView.mCocos2dxRenderer.getCursorPos();
 		Cocos2dxGLSurfaceView.sHandler.sendMessage(msg);
-		
-		
 	}
 
 	public static void closeIMEKeyboard() {

--- a/CrossApp/platform/android/java/src/org/CrossApp/lib/Cocos2dxRenderer.java
+++ b/CrossApp/platform/android/java/src/org/CrossApp/lib/Cocos2dxRenderer.java
@@ -131,6 +131,8 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
 	private static native void nativeAndroidWillInsertText(final int start,final String pString,final int before,final int count);
 	private static native void nativeDeleteBackward();
 	private static native String nativeGetContentText();
+	private static native int nativeGetCursorPos();
+	private static native int[] nativeGetCharRange();
 
 	public void handleInsertText(final String pText) {
 		Cocos2dxRenderer.nativeInsertText(pText);
@@ -146,6 +148,14 @@ public class Cocos2dxRenderer implements GLSurfaceView.Renderer {
 
 	public String getContentText() {
 		return Cocos2dxRenderer.nativeGetContentText();
+	}
+
+	public int getCursorPos() {
+		return Cocos2dxRenderer.nativeGetCursorPos();
+	}
+
+	public int[] getCharRange() {
+		return Cocos2dxRenderer.nativeGetCharRange();
 	}
 
 	// ===========================================================

--- a/CrossApp/platform/android/jni/IMEJni.cpp
+++ b/CrossApp/platform/android/jni/IMEJni.cpp
@@ -61,8 +61,26 @@ extern "C" {
         }
     }
     
+    void setCursorPos(int pos)
+    {
+        JniMethodInfo t;
+        jobject jobj;
+        bool isHave;
+        if (JniHelper::getStaticMethodInfo(t, "org/CrossApp/lib/Cocos2dxGLSurfaceView", "getInstance", "()Lorg/CrossApp/lib/Cocos2dxGLSurfaceView;")) {
+            jobj=t.env->CallStaticObjectMethod(t.classID, t.methodID);
+            isHave = JniHelper::getMethodInfo(t,
+                                              "org/CrossApp/lib/Cocos2dxGLSurfaceView",
+                                              "setCursorPos",
+                                              "(I)V");
+            if (isHave) {
+                t.env->CallVoidMethod(jobj, t.methodID,pos);
+            }
+            t.env->DeleteLocalRef(t.classID);
+        }
+    }
     
-    void closeKeyboardJNI() {
+    void closeKeyboardJNI()
+    {
         JniMethodInfo t;
 
         if (JniHelper::getStaticMethodInfo(t, "org/CrossApp/lib/Cocos2dxGLSurfaceView", "closeIMEKeyboard", "()V")) {
@@ -70,4 +88,5 @@ extern "C" {
             t.env->DeleteLocalRef(t.classID);
         }
     }
+
 }

--- a/CrossApp/platform/android/jni/IMEJni.h
+++ b/CrossApp/platform/android/jni/IMEJni.h
@@ -30,6 +30,7 @@ extern "C" {
     extern void closeKeyboardJNI();
     void setKeyboardType(int type);
     void setKeyboardReturnType(int type);
+    void setCursorPos(int pos);
 }
 
 #endif // __ANDROID_IME_JNI_H__

--- a/CrossApp/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp
+++ b/CrossApp/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp
@@ -53,6 +53,29 @@ extern "C" {
         const char * pszText = CrossApp::CAIMEDispatcher::sharedDispatcher()->getContentText();
         return env->NewStringUTF(pszText);
     }
+
+    JNIEXPORT jint JNICALL Java_org_CrossApp_lib_Cocos2dxRenderer_nativeGetCursorPos() {
+        JNIEnv * env = 0;
+
+        if (JniHelper::getJavaVM()->GetEnv((void**)&env, JNI_VERSION_1_4) != JNI_OK || ! env) {
+            return 0;
+        }
+        return CrossApp::CAIMEDispatcher::sharedDispatcher()->getCursorPos();
+    }
+
+    JNIEXPORT jintArray JNICALL Java_org_CrossApp_lib_Cocos2dxRenderer_nativeGetCharRange() {
+        JNIEnv * env = 0;
+
+        if (JniHelper::getJavaVM()->GetEnv((void**)&env, JNI_VERSION_1_4) != JNI_OK || ! env) {
+            return 0;
+        }
+        std::pair<int, int> ret = CrossApp::CAIMEDispatcher::sharedDispatcher()->getCharRange();
+        jintArray iarr = env->NewIntArray(2);
+        int temp[2] = {ret.first, ret.second};
+        env->SetIntArrayRegion(iarr, 0, 2, temp);
+        return iarr;
+    }
+
     JNIEXPORT void JNICALL Java_org_CrossApp_lib_Cocos2dxActivity_KeyBoardHeightReturn(JNIEnv* env, jobject thiz, jint height) {
         CrossApp::CAIMEDispatcher::sharedDispatcher()->dispatchGetKeyBoardHeight(height);
     }

--- a/CrossApp/platform/android/jni/TouchesJni.cpp
+++ b/CrossApp/platform/android/jni/TouchesJni.cpp
@@ -4,6 +4,7 @@
 #include "dispatcher/CAKeypadDispatcher.h"
 #include "dispatcher/CATouch.h"
 #include "dispatcher/CATouchDispatcher.h"
+#include "dispatcher/CAIMEDispatcher.h"
 #include <android/log.h>
 #include <jni.h>
 #include "platform/android/CCEGLView.h"
@@ -49,6 +50,8 @@ extern "C" {
 
     #define KEYCODE_BACK 0x04
     #define KEYCODE_MENU 0x52
+    #define KEYCODE_DPAD_LEFT 0x15
+    #define KEYCODE_DPAD_RIGHT 0x16
 
     JNIEXPORT jboolean JNICALL Java_org_CrossApp_lib_Cocos2dxRenderer_nativeKeyDown(JNIEnv * env, jobject thiz, jint keyCode) {
         CAApplication* pDirector = CAApplication::getApplication();
@@ -61,6 +64,12 @@ extern "C" {
                 if (pDirector->getKeypadDispatcher()->dispatchKeypadMSG(kTypeMenuClicked))
                     return JNI_TRUE;
                 break;
+            case KEYCODE_DPAD_LEFT:
+                CAIMEDispatcher::sharedDispatcher()->dispatchCursorMoveBackward(false);
+                return JNI_TRUE;
+            case KEYCODE_DPAD_RIGHT:
+                CAIMEDispatcher::sharedDispatcher()->dispatchCursorMoveForward(false);
+                return JNI_TRUE;
             default:
                 return JNI_FALSE;
         }

--- a/CrossApp/view/CAScale9ImageView.cpp
+++ b/CrossApp/view/CAScale9ImageView.cpp
@@ -31,7 +31,7 @@ CAScale9ImageView::CAScale9ImageView()
 , m_pScale9ImageView(NULL)
 {
     m_obFrameRect = CCRectZero;
-    memset(m_pImageView, NULL, sizeof(m_pImageView));
+    memset(m_pImageView, 0, sizeof(m_pImageView));
 }
 
 CAScale9ImageView::~CAScale9ImageView()

--- a/samples/demo/Classes/ViewController/FifthViewController.cpp
+++ b/samples/demo/Classes/ViewController/FifthViewController.cpp
@@ -96,6 +96,7 @@ bool FifthViewController::ccTouchBegan(CATouch *pTouch, CAEvent *pEvent)
 		this->dismissModalViewController(true);
 		return false;
 	}
+    return false;
 }
 
 void FifthViewController::ccTouchMoved(CATouch *pTouch, CAEvent *pEvent)


### PR DESCRIPTION
一、BUG描述：当光标移到前面一点，回删字符，然后将光标移到最后，再回删就不一定删得完
重现步骤如下：
1.输入一串内容，比如123456789
2.通过触摸将光标移到前面一点，比如说现在是这个样子：123|456789
3.回删大于3个字符，比如说回删4个，变成这样：|456789
4.接着再将光标点到后面去，注意期间不能切换输入焦点，这样：456789|
5.然后再一直回删，发现最后剩下1个字符无法删掉
结论：如果之前回删多了N下，那么最后将会有N个字符无法删掉
引起BUG的原因：java代码里面也维护了一份跟C++这边一样的子符串，但是它这边没有记录光标位置，
当通过触摸移动光标时，java这边无法感知到，所以在回删的时候出现误差
改动的代码比较多，请做review

二、改进：增加了通过输入法的方向键移动光标